### PR TITLE
fix: add Helix-compatible textobject captures for ]c/[c navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,26 +195,30 @@ tree-sitter-concerto/
 
 ## Text Objects
 
-The `queries/textobjects.scm` file provides structural text objects compatible with [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) and [Helix](https://helix-editor.com/).
+The `queries/textobjects.scm` file provides structural text objects compatible with both [nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) and [Helix](https://helix-editor.com/) using a dual-capture naming pattern.
 
-| Text Object | Inner (`i`) | Outer (`a`) | Description |
+Each node carries both naming conventions (e.g. `@class.outer @class.around`). Each editor reads only the captures it recognises and ignores the rest.
+
+| Concept | Neovim captures | Helix captures | Description |
 |---|---|---|---|
-| `@class` | Body contents (excluding braces) | Entire declaration including decorators | Works on concept, asset, participant, transaction, event, enum, map, scalar declarations |
-| `@block` | Block contents (excluding braces) | Entire `{ }` block | Works on class, enum, and map bodies |
-| `@parameter` | Individual field/property | — | Works on all field types, enum values, map key/value types |
-| `@assignment` | The assigned value | Entire `default = <value>` clause | Works on all default value clauses |
-| `@comment` | — | Entire comment | Works on line and block comments |
+| Class | `@class.outer` / `@class.inner` | `@class.around` / `@class.inside` | concept, asset, participant, transaction, event, enum, map, scalar |
+| Block | `@block.outer` / `@block.inner` | — | class, enum, and map bodies (Neovim only) |
+| Parameter | `@parameter.inner` | `@parameter.inside` | All field types, enum values, map key/value types |
+| Assignment | `@assignment.outer` / `@assignment.inner` | — | Default value clauses (Neovim only) |
+| Comment | `@comment.outer` | `@comment.around` / `@comment.inside` | Line and block comments |
 
-**Example keybindings** (with nvim-treesitter-textobjects configured):
+**Neovim keybindings** (with nvim-treesitter-textobjects):
 - `vic` — select the fields inside a concept (excluding braces)
 - `vac` — select an entire declaration including its decorators
 - `]c` / `[c` — jump to the next / previous declaration
 - `dap` — delete a single field declaration
 - `cia` — change the value in a `default = ...` clause
 
-**Helix navigation**: `]c` / `[c` for class navigation, `mac` / `mic` for select around/inside class.
-
-> **Note**: Helix uses `class.around`/`class.inside` naming internally but reads `.outer`/`.inner` from query files automatically. No conversion needed.
+**Helix keybindings**:
+- `]c` / `[c` — jump to next / previous declaration
+- `mac` / `mic` — select around / inside a declaration
+- `]a` / `[a` — jump to next / previous parameter (field)
+- `]C` / `[C` — jump to next / previous comment
 
 ## Editor Integration
 

--- a/queries/textobjects.scm
+++ b/queries/textobjects.scm
@@ -1,68 +1,73 @@
 ; Concerto Language - Text Object Queries
 ; =========================================
-; Compatible with nvim-treesitter-textobjects and Helix.
+; Dual-capture pattern for cross-editor compatibility:
+;   Neovim (nvim-treesitter-textobjects): @class.outer / @class.inner
+;   Helix:                                @class.around / @class.inside
 ;
-; Uses standard `_+ @capture` patterns (no custom directives).
-; Works with Neovim 0.10+, nvim-treesitter-textobjects, and Helix.
-;
-; For Helix, map capture names: .outer -> .around, .inner -> .inside
+; Both sets of captures coexist on the same nodes. Each editor reads
+; only the names it recognises and ignores the rest.
 
-; Classes / declarations (@class.outer, @class.inner)
-; vac / vic — select whole declaration / body contents (excluding braces)
+; ---------------------------------------------------------------------------
+; Classes / declarations
+; ---------------------------------------------------------------------------
+; Neovim: vac / vic — select whole declaration / body contents
+; Helix:  ]c / [c — jump next/prev class, mac / mic — select around/inside
 
 (concept_declaration
   (class_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (asset_declaration
   (class_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (participant_declaration
   (class_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (transaction_declaration
   (class_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (event_declaration
   (class_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (enum_declaration
   (enum_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
 (map_declaration
   (map_body
     .
     "{"
-    _+ @class.inner
-    "}")) @class.outer
+    _+ @class.inner @class.inside
+    "}")) @class.outer @class.around
 
-; Scalar declarations have no body braces — outer only
-(scalar_declaration) @class.outer
+; Scalar declarations have no body braces — outer/around only
+(scalar_declaration) @class.outer @class.around
 
-; Block (@block.outer, @block.inner)
+; ---------------------------------------------------------------------------
+; Block (Neovim only — Helix has no @block capture)
+; ---------------------------------------------------------------------------
 ; vab / vib — select whole block / block contents (excluding braces)
 
 (class_body
@@ -83,27 +88,39 @@
   _+ @block.inner
   "}") @block.outer
 
-; Comments (@comment.outer)
-(line_comment) @comment.outer
-(block_comment) @comment.outer
+; ---------------------------------------------------------------------------
+; Comments
+; ---------------------------------------------------------------------------
+; Neovim: @comment.outer
+; Helix:  @comment.around / @comment.inside, ]C / [C for navigation
 
-; Parameters (@parameter.inner) — fields and enum values
-; dap / vip — operate on individual field/property declarations
-; These are the closest analog to "parameters" in a schema language
+(line_comment) @comment.outer @comment.inside
+(block_comment) @comment.outer @comment.inside
 
-(string_field) @parameter.inner
-(boolean_field) @parameter.inner
-(datetime_field) @parameter.inner
-(integer_field) @parameter.inner
-(long_field) @parameter.inner
-(double_field) @parameter.inner
-(object_field) @parameter.inner
-(relationship_field) @parameter.inner
-(enum_property) @parameter.inner
-(map_key_type) @parameter.inner
-(map_value_type) @parameter.inner
+(line_comment) @comment.around
+(block_comment) @comment.around
 
-; Assignment (@assignment.outer, @assignment.inner)
+; ---------------------------------------------------------------------------
+; Parameters — fields, enum values, map entries
+; ---------------------------------------------------------------------------
+; Neovim: @parameter.inner — dap / vip
+; Helix:  @parameter.inside — ]a / [a for navigation, mia / maa to select
+
+(string_field) @parameter.inner @parameter.inside
+(boolean_field) @parameter.inner @parameter.inside
+(datetime_field) @parameter.inner @parameter.inside
+(integer_field) @parameter.inner @parameter.inside
+(long_field) @parameter.inner @parameter.inside
+(double_field) @parameter.inner @parameter.inside
+(object_field) @parameter.inner @parameter.inside
+(relationship_field) @parameter.inner @parameter.inside
+(enum_property) @parameter.inner @parameter.inside
+(map_key_type) @parameter.inner @parameter.inside
+(map_value_type) @parameter.inner @parameter.inside
+
+; ---------------------------------------------------------------------------
+; Assignment (Neovim only — Helix has no @assignment capture)
+; ---------------------------------------------------------------------------
 ; daa / via — operate on default value clauses
 
 (string_default

--- a/test/test-queries.sh
+++ b/test/test-queries.sh
@@ -62,15 +62,17 @@ assert_capture() {
   fi
 }
 
-# @class.outer should match enum and concept declarations
-assert_capture "class.outer" "@class.outer matches enum declaration"
-assert_capture "class.outer" "@class.outer matches concept declaration"
+# Neovim captures
+assert_capture "class.outer" "@class.outer matches declarations (Neovim)"
+assert_capture "class.inner" "@class.inner matches body contents (Neovim)"
+assert_capture "block.outer" "@block.outer matches declaration bodies (Neovim)"
+assert_capture "parameter.inner" "@parameter.inner matches fields/properties (Neovim)"
 
-# @block.outer should match class and enum bodies
-assert_capture "block.outer" "@block.outer matches declaration bodies"
+# Helix captures (dual-named on same nodes)
+assert_capture "class.around" "@class.around matches declarations (Helix)"
+assert_capture "class.inside" "@class.inside matches body contents (Helix)"
+assert_capture "parameter.inside" "@parameter.inside matches fields/properties (Helix)"
 
-# @parameter.inner should match fields and enum properties
-assert_capture "parameter.inner" "@parameter.inner matches fields/properties"
 
 # ---------------------------------------------------------------------------
 # Section 3: Verify textobjects captures on examples/advanced.cto
@@ -94,7 +96,9 @@ assert_adv_capture() {
 assert_adv_capture "class.outer" "@class.outer present for declarations"
 assert_adv_capture "block.outer" "@block.outer present for bodies"
 assert_adv_capture "parameter.inner" "@parameter.inner present for fields"
-assert_adv_capture "comment.outer" "@comment.outer matches comments"
+assert_adv_capture "comment.outer" "@comment.outer matches comments (Neovim)"
+assert_adv_capture "comment.around" "@comment.around matches comments (Helix)"
+assert_adv_capture "comment.inside" "@comment.inside matches comments (Helix)"
 
 # Relationship fields (-->)
 # Relationship fields contain --> in the captured text
@@ -108,11 +112,14 @@ fi
 assert_adv_capture "assignment.outer" "@assignment.outer matches default clauses"
 assert_adv_capture "assignment.inner" "@assignment.inner matches default values"
 
-# @class.inner should match body contents (excluding braces)
-assert_adv_capture "class.inner" "@class.inner present for declaration bodies"
+# Neovim inner captures
+assert_adv_capture "class.inner" "@class.inner present for declaration bodies (Neovim)"
+assert_adv_capture "block.inner" "@block.inner present for block bodies (Neovim)"
 
-# @block.inner should match block contents (excluding braces)
-assert_adv_capture "block.inner" "@block.inner present for block bodies"
+# Helix captures on advanced example
+assert_adv_capture "class.around" "@class.around present for declarations (Helix)"
+assert_adv_capture "class.inside" "@class.inside present for declaration bodies (Helix)"
+assert_adv_capture "parameter.inside" "@parameter.inside present for fields (Helix)"
 
 # ---------------------------------------------------------------------------
 # Section 4: Verify textobjects captures on examples/maps.cto


### PR DESCRIPTION
## Summary

- **Fixes Helix textobject navigation** (`]c`, `[c`, `mac`, `mic`, `]a`, `[a`, etc.) by adding Helix-native capture names alongside the existing Neovim ones
- **Zero impact on Neovim** — all existing Neovim captures remain unchanged
- **Single query file** serves both editors using dual-capture pattern

## Root Cause

Helix and Neovim use different capture name conventions:

| Editor | Outer/Around | Inner/Inside |
|---|---|---|
| Neovim (nvim-treesitter-textobjects) | `@class.outer` | `@class.inner` |
| Helix | `@class.around` | `@class.inside` |

The `textobjects.scm` only had Neovim-style names, so Helix found no captures and `]c` was dead.

## Solution

Tree-sitter allows multiple captures on the same node. Each pattern now carries both conventions:

```scheme
(concept_declaration
  (class_body
    .
    "{"
    _+ @class.inner @class.inside
    "}")) @class.outer @class.around
```

Each editor reads only the names it recognises and ignores the rest.

### Captures added for Helix

| Capture | Helix keybinding | Purpose |
|---|---|---|
| `@class.around` | `mac` | Select entire declaration |
| `@class.inside` | `mic` | Select body contents |
| `@class.around` | `]c` / `[c` | Navigate between declarations |
| `@parameter.inside` | `]a` / `[a` | Navigate between fields |
| `@comment.around` | `]C` / `[C` | Navigate between comments |
| `@comment.inside` | `mic` on comment | Select comment content |

### Files changed

| File | Change |
|---|---|
| `queries/textobjects.scm` | Added Helix captures (`@class.around`, `@class.inside`, `@comment.around`, `@comment.inside`, `@parameter.inside`) |
| `test/test-queries.sh` | Added Helix capture assertions (63 → 71 tests) |
| `README.md` | Updated text objects table with dual-editor documentation |

## Test Results

- 120 corpus tests ✅
- 129 highlight assertions ✅
- 71 query validation tests ✅ (including 8 new Helix-specific assertions)
- **320 total checks, 100% pass**

Co-authored-by: opencode <noreply@opencode.ai>
Signed-off-by: Jamie Shorten <jamie@jamieshorten.com>