### PR TITLE
docs: update README, AGENTS.md, and Copilot instructions for language bindings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,10 +34,11 @@ Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>
 
 ## Tech Stack
 
-- **Grammar**: tree-sitter JavaScript DSL (`grammar.js`)
+- **Grammar**: tree-sitter JavaScript DSL (`grammar.js`, ESM)
 - **Generated parser**: C (`src/parser.c` — auto-generated, do not edit)
 - **Queries**: tree-sitter S-expression queries (`queries/*.scm`)
-- **Tests**: tree-sitter corpus tests (`test/corpus/`), highlight assertion tests (`test/highlight/`), shell-based query validation (`test/test-queries.sh`)
+- **Language bindings**: C, Node.js, Rust, Python, Go, Swift (in `bindings/`)
+- **Tests**: tree-sitter corpus tests (`test/corpus/`), highlight assertion tests (`test/highlight/`), shell-based query validation (`test/test-queries.sh`), Rust and Go binding tests
 - **CLI**: tree-sitter CLI v0.26.7
 
 ## Testing
@@ -47,17 +48,23 @@ Always run tests after making changes:
 ```bash
 tree-sitter test                # Corpus + highlight tests
 bash test/test-queries.sh       # Query validation tests
+cargo test                      # Rust binding test
 ```
 
 ## Key Files
 
-- `grammar.js` — The grammar definition (source of truth)
+- `grammar.js` — The grammar definition (source of truth, ESM)
 - `queries/highlights.scm` — Syntax highlighting
 - `queries/textobjects.scm` — Structural text objects (dual Neovim + Helix captures)
 - `queries/locals.scm` — Scope and reference tracking
 - `queries/indents.scm` — Auto-indentation
 - `queries/folds.scm` — Code folding
 - `src/` — Generated C parser (do not edit manually)
+- `bindings/` — Language bindings (C, Node.js, Rust, Python, Go, Swift)
+- `Cargo.toml` — Rust crate manifest
+- `go.mod` — Go module manifest
+- `pyproject.toml` — Python package manifest
+- `Package.swift` — Swift package manifest
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Concerto is a lightweight, object-oriented data modeling (schema) language desig
 ## Features
 
 - **Complete grammar** covering the full Concerto CTO language specification
-- **120 corpus tests** all passing, plus **129 highlight assertions** and **63 query validation tests**
-- **CI pipeline** via GitHub Actions (multi-platform parser tests, query validation)
+- **Language bindings** for C, Node.js, Rust, Python, Go, and Swift
+- **120 corpus tests** all passing, plus **129 highlight assertions** and **71 query validation tests**
+- **CI pipeline** via GitHub Actions (multi-platform parser tests, query validation, Rust and Go binding tests)
 - **Syntax highlighting queries** for editor integration
 - **Text object queries** for structural editing (compatible with nvim-treesitter-textobjects and Helix)
 - **Fold queries** for code folding
@@ -172,13 +173,28 @@ The parser produces a concrete syntax tree like:
 ## Project Structure
 
 ```
-tree-sitter-concerto/
-  grammar.js          # The tree-sitter grammar definition
+concerto-tree-sitter/
+  grammar.js          # The tree-sitter grammar definition (ESM)
   tree-sitter.json    # Tree-sitter configuration
   package.json        # Node.js package manifest
+  Cargo.toml          # Rust crate manifest
+  go.mod              # Go module manifest
+  pyproject.toml      # Python package manifest
+  Package.swift       # Swift package manifest
+  CMakeLists.txt      # CMake build configuration
+  Makefile            # C library build
+  binding.gyp         # Node.js native addon build
   .github/
     workflows/
       ci.yml          # GitHub Actions CI pipeline
+    copilot-instructions.md  # GitHub Copilot instructions
+  bindings/
+    c/                # C header and pkg-config template
+    node/             # Node.js native addon binding
+    rust/             # Rust crate binding
+    python/           # Python C extension binding
+    go/               # Go cgo binding
+    swift/            # Swift package binding
   queries/
     highlights.scm    # Syntax highlighting queries
     textobjects.scm   # Text object queries (Neovim + Helix compatible)
@@ -188,7 +204,7 @@ tree-sitter-concerto/
   test/
     corpus/           # Tree-sitter test corpus (120 tests)
     highlight/        # Syntax highlighting assertion tests (129 assertions)
-    test-queries.sh   # Query validation test script (63 tests)
+    test-queries.sh   # Query validation test script (71 tests)
   examples/           # Example .cto files (validated with concerto-cli)
   src/                # Generated C parser (auto-generated, do not edit)
 ```
@@ -429,7 +445,7 @@ The project has three layers of testing:
 - Uses tree-sitter's built-in Sublime Text–style assertion format
 - Run automatically as part of `tree-sitter test`
 
-**3. Query validation tests** (63 tests in `test/test-queries.sh`)
+**3. Query validation tests** (71 tests in `test/test-queries.sh`)
 - Verifies all 5 query files compile and execute against all 6 examples without errors
 - Asserts expected textobject captures (`@class.outer`, `@class.inner`, `@block.outer`, `@block.inner`, `@parameter.inner`, `@assignment.*`, `@comment.outer`) are present
 - Asserts expected fold captures are present

--- a/agents.md
+++ b/agents.md
@@ -227,6 +227,8 @@ Architect Agent (orchestrator)
     +-- Architect: Created highlight tests, query validation, CI pipeline (Phase 8)
     |
     +-- Architect: Rewrote textobjects.scm, added folds.scm, updated README (Phase 9)
+    |
+    +-- Architect: Generated language bindings, fixed CI, added binding tests (Phase 10)
 ```
 
 ### Phase 9: Editor Compatibility Fix
@@ -265,15 +267,61 @@ Architect Agent (orchestrator)
     "}")) @class.outer
 ```
 
+### Phase 10: Language Bindings & Editor Distribution
+
+**Objective**: Generate standard tree-sitter language bindings so the parser can be consumed as a library from multiple ecosystems, and add CI coverage for bindings.
+
+**Actions**:
+1. Ran `tree-sitter init --update` to generate bindings for C, Node.js, Rust, Python, Go, and Swift
+2. Migrated `grammar.js` from CommonJS to ESM (`module.exports` → `export default`)
+3. Added `"type": "module"` to `package.json`
+4. Restored `folds.scm` reference in `tree-sitter.json` (dropped by `init --update`)
+5. Added `.editorconfig` and `.gitattributes` for consistent formatting
+6. Updated `.gitignore` for new build artifacts (Cargo.lock, go.sum, .build/, etc.)
+7. Added Rust and Go binding tests to CI pipeline
+8. Fixed Rust doctest (empty string → valid Concerto snippet)
+9. Fixed Go CI (added `go mod tidy` to generate missing `go.sum`)
+10. Removed Node binding test from CI (legacy `tree-sitter` npm package incompatibility with ABI v15)
+
+**Files generated**:
+
+| Category | Files |
+|---|---|
+| C bindings | `bindings/c/tree_sitter/tree-sitter-concerto.h`, `bindings/c/tree-sitter-concerto.pc.in`, `CMakeLists.txt`, `Makefile` |
+| Node.js bindings | `bindings/node/binding.cc`, `bindings/node/index.js`, `bindings/node/index.d.ts`, `bindings/node/binding_test.js`, `binding.gyp` |
+| Rust bindings | `bindings/rust/lib.rs`, `bindings/rust/build.rs`, `Cargo.toml` |
+| Python bindings | `bindings/python/tree_sitter_concerto/__init__.py`, `__init__.pyi`, `binding.c`, `py.typed`, `tests/test_binding.py`, `pyproject.toml`, `setup.py` |
+| Go bindings | `bindings/go/binding.go`, `bindings/go/binding_test.go`, `go.mod` |
+| Swift bindings | `bindings/swift/TreeSitterConcerto/concerto.h`, `TreeSitterConcertoTests/TreeSitterConcertoTests.swift`, `Package.swift` |
+| Config | `.editorconfig`, `.gitattributes` |
+
+**CI binding tests**:
+
+| Binding | CI job | Status |
+|---|---|---|
+| Rust | `cargo test` | ✅ In CI |
+| Go | `go test ./bindings/go/` | ✅ In CI |
+| Node.js | `node --test bindings/node/binding_test.js` | ❌ Removed — legacy npm package incompatibility |
+| Python | `pip install . && python -m pytest` | ⏳ Deferred — heavy setup |
+| Swift | `swift test` | ⏳ Deferred — requires macOS + Xcode |
+
+**Key issues encountered**:
+- Rust doctest failed because it parsed an empty string, but Concerto requires a namespace declaration — fixed by providing a valid snippet
+- Go test failed due to missing `go.sum` — fixed by adding `go mod tidy` to CI
+- Node binding test had an async/await bug, then a deeper ABI incompatibility with the legacy `tree-sitter` npm package (v0.21) — removed from CI
+
 ## Metrics
 
-- **Grammar size**: ~627 lines of JavaScript
+- **Grammar size**: ~627 lines of JavaScript (ESM)
 - **Generated parser**: ~47,000 lines of C
+- **Language bindings**: 6 ecosystems (C, Node.js, Rust, Python, Go, Swift)
 - **Test corpus**: 120 tests across 12 files
 - **Highlight tests**: 129 assertions across 4 files
-- **Query validation tests**: 63 tests
-- **Total test checks**: 312
+- **Query validation tests**: 71 tests
+- **Binding tests in CI**: 2 (Rust, Go)
+- **Total test checks**: 322+
 - **Test pass rate**: 100%
+- **CI jobs**: 7 (3× parser, query validation, Rust binding, Go binding, DCO)
 - **Example files**: 6 validated .cto files
 - **Syntax highlighting queries**: 230+ lines covering all node types
 - **Text object queries**: 108 lines, 5 capture groups (`@class`, `@block`, `@parameter`, `@assignment`, `@comment`)


### PR DESCRIPTION
## Summary

Updates all three documentation/instruction files to reflect the language bindings added in PR #5.

- **README.md**: Add language bindings to features, update project structure tree, fix stale test count (63 → 71), mention binding tests in CI description
- **AGENTS.md**: Add Phase 10 documenting the full bindings generation process, CI issues encountered, and resolutions; update metrics and agent collaboration pattern
- **copilot-instructions.md**: Add bindings to tech stack and key files sections, add `cargo test` to testing commands

## Why

After merging PR #5 (language bindings), the documentation was stale — no mention of bindings, package manifests, or binding CI tests. The AGENTS.md development log was also missing the Phase 10 record.