### PR TITLE
feat: add editor-specific query files for Helix and nvim-treesitter submissions

### DIFF
--- a/editor/helix/languages.toml.snippet
+++ b/editor/helix/languages.toml.snippet
@@ -1,0 +1,16 @@
+# Concerto Modelling Language
+# Add this [[language]] block to the language table in languages.toml (alphabetically sorted)
+# Add the [[grammar]] block to the grammar table at the bottom
+
+[[language]]
+name = "concerto"
+scope = "source.concerto"
+injection-regex = "concerto"
+file-types = ["cto"]
+comment-tokens = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "concerto"
+source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "de6a8f87024824ed904b3def3f900cd7bd705ba1" }

--- a/editor/helix/queries/concerto/highlights.scm
+++ b/editor/helix/queries/concerto/highlights.scm
@@ -1,0 +1,235 @@
+; Concerto Language - Syntax Highlighting Queries (Helix)
+; =======================================================
+; Helix-specific capture names. For use in helix-editor/helix at
+; runtime/queries/concerto/highlights.scm
+;
+; Precedence: later patterns override earlier ones (last match wins).
+
+; Keywords
+; --------
+
+; Declaration keywords
+[
+  "concept"
+  "asset"
+  "participant"
+  "transaction"
+  "event"
+  "enum"
+  "scalar"
+  "map"
+] @keyword.storage.type
+
+[
+  "namespace"
+  "import"
+  "from"
+] @keyword.control.import
+
+[
+  "extends"
+] @keyword
+
+[
+  "abstract"
+] @keyword.storage.modifier
+
+[
+  "identified"
+  "by"
+] @keyword
+
+[
+  "optional"
+] @keyword.storage.modifier
+
+[
+  "concerto"
+  "version"
+] @keyword
+
+[
+  "default"
+] @keyword
+
+[
+  "regex"
+  "range"
+  "length"
+] @keyword
+
+[
+  "as"
+] @keyword
+
+; Primitive type keywords
+[
+  "String"
+  "Boolean"
+  "DateTime"
+  "Integer"
+  "Long"
+  "Double"
+] @type.builtin
+
+(primitive_type) @type.builtin
+
+; Boolean literals
+(boolean_literal) @constant.builtin.boolean
+
+; Comments
+; --------
+(line_comment) @comment.line
+(block_comment) @comment.block
+
+; Strings
+; -------
+(string_literal) @string
+(escape_sequence) @constant.character.escape
+
+; Numbers
+; -------
+(signed_integer) @constant.numeric
+(signed_real) @constant.numeric
+(signed_number) @constant.numeric
+
+; Regex
+; -----
+(regex_literal) @string.regexp
+
+; Decorators
+; ----------
+(decorator
+  "@" @attribute
+  name: (identifier) @attribute)
+
+; Namespace and imports
+; --------------------
+(namespace_path) @namespace
+
+(import_path) @namespace
+
+(uri) @string.special
+
+; Version
+; -------
+(concerto_version
+  (string_literal) @string.special)
+
+; Type identifiers (in type position)
+; -----------------------------------
+(concept_declaration
+  name: (type_identifier) @type)
+
+(asset_declaration
+  name: (type_identifier) @type)
+
+(participant_declaration
+  name: (type_identifier) @type)
+
+(transaction_declaration
+  name: (type_identifier) @type)
+
+(event_declaration
+  name: (type_identifier) @type)
+
+(enum_declaration
+  name: (type_identifier) @type)
+
+(scalar_declaration
+  name: (type_identifier) @type)
+
+(map_declaration
+  name: (type_identifier) @type)
+
+(extends_clause
+  (type_identifier) @type)
+
+; Field type references
+(object_field
+  type: (type_identifier) @type)
+
+(relationship_field
+  type: (type_identifier) @type)
+
+; Map type references
+(map_key_type
+  type: (type_identifier) @type)
+
+(map_value_property
+  type: (type_identifier) @type)
+
+(map_value_relationship
+  type: (type_identifier) @type)
+
+; Decorator identifier references
+(decorator_identifier_ref
+  (type_identifier) @type)
+
+; Import type name
+(import_single
+  type: (identifier) @type)
+
+(type_list_item
+  (identifier) @type)
+
+(aliased_type
+  original: (identifier) @type
+  alias: (identifier) @type)
+
+; Field/property names
+; --------------------
+(string_field
+  name: (identifier) @variable.other.member)
+
+(boolean_field
+  name: (identifier) @variable.other.member)
+
+(datetime_field
+  name: (identifier) @variable.other.member)
+
+(integer_field
+  name: (identifier) @variable.other.member)
+
+(long_field
+  name: (identifier) @variable.other.member)
+
+(double_field
+  name: (identifier) @variable.other.member)
+
+(object_field
+  name: (identifier) @variable.other.member)
+
+(relationship_field
+  name: (identifier) @variable.other.member)
+
+(enum_property
+  name: (identifier) @variable.other.member)
+
+; Identified by field name
+(identified_by
+  field: (identifier) @variable.other.member)
+
+; Relationship arrow
+"-->" @operator
+
+; Property indicator
+"o" @punctuation.special
+
+; Array indicator
+(array_indicator) @punctuation.bracket
+
+; Wildcards in imports
+"*" @operator
+
+; Delimiters
+; ----------
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"," @punctuation.delimiter
+"." @punctuation.delimiter
+"=" @operator

--- a/editor/helix/queries/concerto/indents.scm
+++ b/editor/helix/queries/concerto/indents.scm
@@ -1,0 +1,21 @@
+; Concerto Language - Indent Queries (Helix)
+; ============================================
+; Helix-specific indentation rules. For use in helix-editor/helix at
+; runtime/queries/concerto/indents.scm
+;
+; Helix uses @indent and @outdent captures, same as tree-sitter convention.
+; See: https://docs.helix-editor.com/guides/indent.html
+
+; Indent inside declaration bodies and decorator argument lists
+[
+  (class_body)
+  (enum_body)
+  (map_body)
+  (decorator_arguments)
+] @indent
+
+; Outdent at closing braces and parentheses
+[
+  "}"
+  ")"
+] @outdent

--- a/editor/helix/queries/concerto/locals.scm
+++ b/editor/helix/queries/concerto/locals.scm
@@ -1,0 +1,88 @@
+; Concerto Language - Locals Queries (Helix)
+; ============================================
+; Helix-specific local scope/definition/reference tracking. For use in
+; helix-editor/helix at runtime/queries/concerto/locals.scm
+;
+; Helix uses the same @local.scope, @local.definition, and @local.reference
+; capture names as tree-sitter convention.
+
+; Scopes
+; ------
+
+; Each declaration body creates a new scope
+(concept_declaration) @local.scope
+(asset_declaration) @local.scope
+(participant_declaration) @local.scope
+(transaction_declaration) @local.scope
+(event_declaration) @local.scope
+(enum_declaration) @local.scope
+(map_declaration) @local.scope
+
+; Definitions
+; -----------
+
+; Type declarations define types
+(concept_declaration
+  name: (type_identifier) @local.definition)
+
+(asset_declaration
+  name: (type_identifier) @local.definition)
+
+(participant_declaration
+  name: (type_identifier) @local.definition)
+
+(transaction_declaration
+  name: (type_identifier) @local.definition)
+
+(event_declaration
+  name: (type_identifier) @local.definition)
+
+(enum_declaration
+  name: (type_identifier) @local.definition)
+
+(scalar_declaration
+  name: (type_identifier) @local.definition)
+
+(map_declaration
+  name: (type_identifier) @local.definition)
+
+; Property declarations define properties
+(string_field
+  name: (identifier) @local.definition)
+
+(boolean_field
+  name: (identifier) @local.definition)
+
+(datetime_field
+  name: (identifier) @local.definition)
+
+(integer_field
+  name: (identifier) @local.definition)
+
+(long_field
+  name: (identifier) @local.definition)
+
+(double_field
+  name: (identifier) @local.definition)
+
+(object_field
+  name: (identifier) @local.definition)
+
+(relationship_field
+  name: (identifier) @local.definition)
+
+(enum_property
+  name: (identifier) @local.definition)
+
+; References
+; ----------
+
+; Type references
+(extends_clause
+  (type_identifier) @local.reference)
+
+(object_field
+  type: (type_identifier) @local.reference)
+
+(relationship_field
+  type: (type_identifier) @local.reference)

--- a/editor/helix/queries/concerto/textobjects.scm
+++ b/editor/helix/queries/concerto/textobjects.scm
@@ -1,0 +1,95 @@
+; Concerto Language - Text Object Queries (Helix)
+; =================================================
+; Helix-specific text objects. For use in helix-editor/helix at
+; runtime/queries/concerto/textobjects.scm
+;
+; Helix uses @<object>.around / @<object>.inside suffixes.
+; See: https://docs.helix-editor.com/guides/textobject.html
+
+; ---------------------------------------------------------------------------
+; Classes / declarations
+; ---------------------------------------------------------------------------
+; mac / mic — select around/inside class
+; ]c / [c   — jump to next/prev class boundary
+
+(concept_declaration
+  (class_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(asset_declaration
+  (class_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(participant_declaration
+  (class_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(transaction_declaration
+  (class_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(event_declaration
+  (class_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(enum_declaration
+  (enum_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+(map_declaration
+  (map_body
+    .
+    "{"
+    _+ @class.inside
+    "}")) @class.around
+
+; Scalar declarations have no body braces — around only
+(scalar_declaration) @class.around
+
+; ---------------------------------------------------------------------------
+; Comments
+; ---------------------------------------------------------------------------
+; ]C / [C — jump to next/prev comment
+; maC / miC — select around/inside comment
+
+(line_comment) @comment.inside
+(block_comment) @comment.inside
+
+(line_comment) @comment.around
+(block_comment) @comment.around
+
+; ---------------------------------------------------------------------------
+; Parameters — fields, enum values, map entries
+; ---------------------------------------------------------------------------
+; ]a / [a — jump to next/prev parameter
+; maa / mia — select around/inside parameter
+
+(string_field) @parameter.inside
+(boolean_field) @parameter.inside
+(datetime_field) @parameter.inside
+(integer_field) @parameter.inside
+(long_field) @parameter.inside
+(double_field) @parameter.inside
+(object_field) @parameter.inside
+(relationship_field) @parameter.inside
+(enum_property) @parameter.inside
+(map_key_type) @parameter.inside
+(map_value_type) @parameter.inside

--- a/editor/nvim-treesitter/filetypes.lua.snippet
+++ b/editor/nvim-treesitter/filetypes.lua.snippet
@@ -1,0 +1,9 @@
+-- Add this entry to plugin/filetypes.lua (alphabetically sorted)
+-- This registers .cto files as the "concerto" filetype since Neovim
+-- does not yet detect it natively.
+
+vim.filetype.add {
+  extension = {
+    cto = 'concerto',
+  },
+}

--- a/editor/nvim-treesitter/parsers.lua.snippet
+++ b/editor/nvim-treesitter/parsers.lua.snippet
@@ -1,0 +1,11 @@
+-- Add this entry to lua/nvim-treesitter/parsers.lua (alphabetically sorted)
+-- between "comment" and "commonlisp"
+
+concerto = {
+  install_info = {
+    url = 'https://github.com/accordproject/concerto-tree-sitter',
+    revision = 'de6a8f87024824ed904b3def3f900cd7bd705ba1',
+  },
+  maintainers = { '@jamieshorten' },
+  tier = 2,
+},

--- a/editor/nvim-treesitter/queries/concerto/folds.scm
+++ b/editor/nvim-treesitter/queries/concerto/folds.scm
@@ -1,0 +1,13 @@
+; Concerto Language - Fold Queries
+; =================================
+
+; Fold declaration bodies
+(class_body) @fold
+(enum_body) @fold
+(map_body) @fold
+
+; Fold block comments
+(block_comment) @fold
+
+; Fold decorator argument lists
+(decorator_arguments) @fold

--- a/editor/nvim-treesitter/queries/concerto/highlights.scm
+++ b/editor/nvim-treesitter/queries/concerto/highlights.scm
@@ -1,0 +1,231 @@
+; Concerto Language - Syntax Highlighting Queries
+; =================================================
+
+; Keywords
+; --------
+
+; Declaration keywords
+[
+  "concept"
+  "asset"
+  "participant"
+  "transaction"
+  "event"
+  "enum"
+  "scalar"
+  "map"
+] @keyword.type
+
+[
+  "namespace"
+  "import"
+  "from"
+] @keyword.import
+
+[
+  "extends"
+] @keyword
+
+[
+  "abstract"
+] @keyword.modifier
+
+[
+  "identified"
+  "by"
+] @keyword
+
+[
+  "optional"
+] @keyword.modifier
+
+[
+  "concerto"
+  "version"
+] @keyword
+
+[
+  "default"
+] @keyword
+
+[
+  "regex"
+  "range"
+  "length"
+] @keyword
+
+[
+  "as"
+] @keyword
+
+; Primitive type keywords
+[
+  "String"
+  "Boolean"
+  "DateTime"
+  "Integer"
+  "Long"
+  "Double"
+] @type.builtin
+
+(primitive_type) @type.builtin
+
+; Boolean literals
+(boolean_literal) @boolean
+
+; Comments
+; --------
+(line_comment) @comment
+(block_comment) @comment
+
+; Strings
+; -------
+(string_literal) @string
+(escape_sequence) @string.escape
+
+; Numbers
+; -------
+(signed_integer) @number
+(signed_real) @number
+(signed_number) @number
+
+; Regex
+; -----
+(regex_literal) @string.regex
+
+; Decorators
+; ----------
+(decorator
+  "@" @attribute
+  name: (identifier) @attribute)
+
+; Namespace and imports
+; --------------------
+(namespace_path) @namespace
+
+(import_path) @namespace
+
+(uri) @string.special
+
+; Version
+; -------
+(concerto_version
+  (string_literal) @string.special)
+
+; Type identifiers (in type position)
+; -----------------------------------
+(concept_declaration
+  name: (type_identifier) @type)
+
+(asset_declaration
+  name: (type_identifier) @type)
+
+(participant_declaration
+  name: (type_identifier) @type)
+
+(transaction_declaration
+  name: (type_identifier) @type)
+
+(event_declaration
+  name: (type_identifier) @type)
+
+(enum_declaration
+  name: (type_identifier) @type)
+
+(scalar_declaration
+  name: (type_identifier) @type)
+
+(map_declaration
+  name: (type_identifier) @type)
+
+(extends_clause
+  (type_identifier) @type)
+
+; Field type references
+(object_field
+  type: (type_identifier) @type)
+
+(relationship_field
+  type: (type_identifier) @type)
+
+; Map type references
+(map_key_type
+  type: (type_identifier) @type)
+
+(map_value_property
+  type: (type_identifier) @type)
+
+(map_value_relationship
+  type: (type_identifier) @type)
+
+; Decorator identifier references
+(decorator_identifier_ref
+  (type_identifier) @type)
+
+; Import type name
+(import_single
+  type: (identifier) @type)
+
+(type_list_item
+  (identifier) @type)
+
+(aliased_type
+  original: (identifier) @type
+  alias: (identifier) @type)
+
+; Field/property names
+; --------------------
+(string_field
+  name: (identifier) @property)
+
+(boolean_field
+  name: (identifier) @property)
+
+(datetime_field
+  name: (identifier) @property)
+
+(integer_field
+  name: (identifier) @property)
+
+(long_field
+  name: (identifier) @property)
+
+(double_field
+  name: (identifier) @property)
+
+(object_field
+  name: (identifier) @property)
+
+(relationship_field
+  name: (identifier) @property)
+
+(enum_property
+  name: (identifier) @property)
+
+; Identified by field name
+(identified_by
+  field: (identifier) @property)
+
+; Relationship arrow
+"-->" @operator
+
+; Property indicator
+"o" @punctuation.special
+
+; Array indicator
+(array_indicator) @punctuation.bracket
+
+; Wildcards in imports
+"*" @operator
+
+; Delimiters
+; ----------
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"," @punctuation.delimiter
+"." @punctuation.delimiter
+"=" @operator

--- a/editor/nvim-treesitter/queries/concerto/indents.scm
+++ b/editor/nvim-treesitter/queries/concerto/indents.scm
@@ -1,0 +1,16 @@
+; Concerto Language - Indent Queries
+; ===================================
+
+; Indent inside declaration bodies
+[
+  (class_body)
+  (enum_body)
+  (map_body)
+  (decorator_arguments)
+] @indent
+
+; Outdent at closing braces
+[
+  "}"
+  ")"
+] @outdent

--- a/editor/nvim-treesitter/queries/concerto/locals.scm
+++ b/editor/nvim-treesitter/queries/concerto/locals.scm
@@ -1,0 +1,83 @@
+; Concerto Language - Locals Queries
+; ===================================
+
+; Scopes
+; ------
+
+; Each declaration body creates a new scope
+(concept_declaration) @local.scope
+(asset_declaration) @local.scope
+(participant_declaration) @local.scope
+(transaction_declaration) @local.scope
+(event_declaration) @local.scope
+(enum_declaration) @local.scope
+(map_declaration) @local.scope
+
+; Definitions
+; -----------
+
+; Type declarations define types
+(concept_declaration
+  name: (type_identifier) @local.definition)
+
+(asset_declaration
+  name: (type_identifier) @local.definition)
+
+(participant_declaration
+  name: (type_identifier) @local.definition)
+
+(transaction_declaration
+  name: (type_identifier) @local.definition)
+
+(event_declaration
+  name: (type_identifier) @local.definition)
+
+(enum_declaration
+  name: (type_identifier) @local.definition)
+
+(scalar_declaration
+  name: (type_identifier) @local.definition)
+
+(map_declaration
+  name: (type_identifier) @local.definition)
+
+; Property declarations define properties
+(string_field
+  name: (identifier) @local.definition)
+
+(boolean_field
+  name: (identifier) @local.definition)
+
+(datetime_field
+  name: (identifier) @local.definition)
+
+(integer_field
+  name: (identifier) @local.definition)
+
+(long_field
+  name: (identifier) @local.definition)
+
+(double_field
+  name: (identifier) @local.definition)
+
+(object_field
+  name: (identifier) @local.definition)
+
+(relationship_field
+  name: (identifier) @local.definition)
+
+(enum_property
+  name: (identifier) @local.definition)
+
+; References
+; ----------
+
+; Type references
+(extends_clause
+  (type_identifier) @local.reference)
+
+(object_field
+  type: (type_identifier) @local.reference)
+
+(relationship_field
+  type: (type_identifier) @local.reference)


### PR DESCRIPTION
## Summary

Prepares all files needed to submit Concerto language support to **Helix** and **nvim-treesitter** upstream. These files live in `editor/` in our repo and will be copied/adapted into PRs to the respective external repos.

## Helix (`editor/helix/`)

| File | Purpose |
|---|---|
| `queries/concerto/highlights.scm` | Syntax highlighting with Helix capture conventions |
| `queries/concerto/textobjects.scm` | Text objects with `.around`/`.inside` captures only |
| `queries/concerto/indents.scm` | Auto-indentation (`@indent`/`@outdent`) |
| `queries/concerto/locals.scm` | Scope/definition/reference tracking |
| `languages.toml.snippet` | `[[language]]` and `[[grammar]]` entries to add |

**Helix capture translations applied** (10 changes from nvim-treesitter conventions):

| nvim-treesitter | Helix |
|---|---|
| `@keyword.type` | `@keyword.storage.type` |
| `@keyword.import` | `@keyword.control.import` |
| `@keyword.modifier` | `@keyword.storage.modifier` |
| `@boolean` | `@constant.builtin.boolean` |
| `@comment` | `@comment.line` / `@comment.block` |
| `@string.escape` | `@constant.character.escape` |
| `@number` | `@constant.numeric` |
| `@string.regex` | `@string.regexp` |
| `@property` | `@variable.other.member` |

## nvim-treesitter (`editor/nvim-treesitter/`)

| File | Purpose |
|---|---|
| `queries/concerto/highlights.scm` | Syntax highlighting (same as main `queries/`) |
| `queries/concerto/folds.scm` | Code folding |
| `queries/concerto/locals.scm` | Scope/definition/reference tracking |
| `queries/concerto/indents.scm` | Auto-indentation |
| `parsers.lua.snippet` | Parser registry entry (tier 2) |
| `filetypes.lua.snippet` | `.cto` → `concerto` filetype registration |

## Testing

- All Helix queries validated against all 6 example `.cto` files — zero errors
- All 120 corpus tests, 129 highlight assertions, and 71 query validation tests still pass

## Next steps

After this merges:
1. Submit PR to `helix-editor/helix` using the Helix files + `cargo xtask docgen`
2. Submit PR to `nvim-treesitter/nvim-treesitter` using the nvim-treesitter files + `make docs`
3. Submit follow-up PR to `nvim-treesitter/nvim-treesitter-textobjects` for text objects