### PR TITLE
fix: correct commit SHAs and nvim-treesitter capture names in editor snippets

### DIFF
--- a/editor/helix/languages.toml.snippet
+++ b/editor/helix/languages.toml.snippet
@@ -13,4 +13,4 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "concerto"
-source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "de6a8f87024824ed904b3def3f900cd7bd705ba1" }
+source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "77ae6b94eb0e249d1e5738c60eceed790c27563b" }

--- a/editor/nvim-treesitter/parsers.lua.snippet
+++ b/editor/nvim-treesitter/parsers.lua.snippet
@@ -4,8 +4,8 @@
 concerto = {
   install_info = {
     url = 'https://github.com/accordproject/concerto-tree-sitter',
-    revision = 'de6a8f87024824ed904b3def3f900cd7bd705ba1',
+    revision = '77ae6b94eb0e249d1e5738c60eceed790c27563b',
   },
   maintainers = { '@jamieshorten' },
-  tier = 2,
+  tier = 3,
 },

--- a/editor/nvim-treesitter/queries/concerto/highlights.scm
+++ b/editor/nvim-treesitter/queries/concerto/highlights.scm
@@ -91,7 +91,7 @@
 
 ; Regex
 ; -----
-(regex_literal) @string.regex
+(regex_literal) @string.regexp
 
 ; Decorators
 ; ----------
@@ -101,9 +101,9 @@
 
 ; Namespace and imports
 ; --------------------
-(namespace_path) @namespace
+(namespace_path) @module
 
-(import_path) @namespace
+(import_path) @module
 
 (uri) @string.special
 

--- a/editor/nvim-treesitter/queries/concerto/indents.scm
+++ b/editor/nvim-treesitter/queries/concerto/indents.scm
@@ -7,10 +7,10 @@
   (enum_body)
   (map_body)
   (decorator_arguments)
-] @indent
+] @indent.begin
 
 ; Outdent at closing braces
 [
   "}"
   ")"
-] @outdent
+] @indent.end


### PR DESCRIPTION
## Summary

Fixes bugs in the editor submission snippets discovered when the nvim-treesitter PR CI failed and was closed.

### Issues found and fixed

1. **Wrong commit SHAs** — The `rev` fields in both `languages.toml.snippet` (Helix) and `parsers.lua.snippet` (nvim-treesitter) had incorrect SHAs that didn't exist in the repo, causing 404 errors when nvim-treesitter's CI tried to download the grammar tarball.

2. **Outdated nvim-treesitter capture names** — Three captures have been renamed in the nvim-treesitter ecosystem:
   - `@namespace` → `@module`
   - `@string.regex` → `@string.regexp`
   - `@indent` / `@outdent` → `@indent.begin` / `@indent.end`

3. **Wrong tier** — Changed from tier 2 (unstable) to tier 3 (unmaintained) which is the correct tier for new parsers with a single maintainer per nvim-treesitter conventions.

### Context

The nvim-treesitter PR (#8594) was closed by @clason with feedback that:
- The project is too new for upstream inclusion
- `.cto` needs to be an officially supported filetype in Vim first
- Tests were failing (due to the SHA and capture name issues fixed here)

The Helix PR (#15472) is still open and has been updated with the correct SHA.

The nvim-treesitter fork (`jamieshorten/nvim-treesitter`) has also been updated with all fixes and is maintained for future resubmission.