### PR TITLE
fix: replace hardcoded SHAs with placeholders in editor snippets

### DIFF
--- a/editor/helix/languages.toml.snippet
+++ b/editor/helix/languages.toml.snippet
@@ -13,4 +13,5 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "concerto"
-source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "de6a8f87024824ed904b3def3f900cd7bd705ba1" }
+# Replace <COMMIT_SHA> with the full SHA of the desired commit: git rev-parse HEAD
+source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "<COMMIT_SHA>" }

--- a/editor/nvim-treesitter/parsers.lua.snippet
+++ b/editor/nvim-treesitter/parsers.lua.snippet
@@ -4,8 +4,9 @@
 concerto = {
   install_info = {
     url = 'https://github.com/accordproject/concerto-tree-sitter',
-    revision = 'de6a8f87024824ed904b3def3f900cd7bd705ba1',
+    -- Replace <COMMIT_SHA> with the full SHA of the desired commit: git rev-parse HEAD
+    revision = '<COMMIT_SHA>',
   },
   maintainers = { '@jamieshorten' },
-  tier = 2,
+  tier = 3,
 },


### PR DESCRIPTION
## Summary

Replace stale hardcoded commit SHAs in `editor/helix/languages.toml.snippet` and `editor/nvim-treesitter/parsers.lua.snippet` with `<COMMIT_SHA>` placeholders and a `git rev-parse HEAD` instruction.

This was the recommended fix when PR #9 was closed — hardcoded SHAs are stale the moment a new commit lands.

Also fixes nvim-treesitter tier from 2 → 3 (correct for new parsers with a single maintainer).